### PR TITLE
Update types to handle window.removeEventListener

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,5 +13,11 @@ declare global {
       callback: (event: UrlChangeEvent) => void,
       options?: boolean | AddEventListenerOptions
     ): void
+    
+    removeEventListener(
+      type: "urlchangeevent",
+      callback: (event: UrlChangeEvent) => void,
+      options?: boolean | AddEventListenerOptions
+    ): void;
   }
 }


### PR DESCRIPTION
Currently causing a TS error when I try to remove the event listener.